### PR TITLE
Fix Pages base path for deploy smoke tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,9 @@ jobs:
       # Runs the same suite but only chromium
       - name: Run Playwright smoke
         run: npx playwright test --project=chromium
+        env:
+          APP_BASE_PATH: "/PortfolioReactAppRepo/"
+          PLAYWRIGHT_BASE_URL: "http://127.0.0.1:4173"
 
       # Don't deploy if budgets regress on main
       - name: Audit with Lighthouse CI

--- a/e2e/pages/HomePage.ts
+++ b/e2e/pages/HomePage.ts
@@ -8,7 +8,8 @@ export class HomePage {
   constructor(private readonly page: Page) {}
 
   async goto() {
-    await this.page.goto("/");
+    const basePath = (process.env.APP_BASE_PATH || "/").trim();
+    await this.page.goto(basePath.startsWith("/") ? basePath : `/${basePath}`);
   }
 
   // Works whether your nav item is implemented as <a> or <button>


### PR DESCRIPTION


### PR Quality Gate worked fine and all tests passed

---

### Issue:

Base path in deploy.yml was targetting / but github pages uses /repo/ to deploy the live site

###Fix:

Improved logic of playwright.config to add APP_BASE_PATH support + makes webServer.url correct.

--- 