### PR TITLE
fix: Correct command to run backend tests in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run backend tests
         run: |
           cd portfolio-chatbot
-          npm test:ci
+          npm run test:ci
 
       - name: Write backend summary
         if: always()


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by correcting the command used to run backend tests. The script now uses the proper `npm run` syntax to execute the test suite in continuous integration mode.

- Changed the backend test command from `npm test:ci` to `npm run test:ci` in `.github/workflows/deploy.yml` to ensure correct execution of the test script.