### PR TITLE
fix: update worker readiness check in weekly regression suite and rem…

### DIFF
--- a/.github/workflows/weekly-regression-gates.yml
+++ b/.github/workflows/weekly-regression-gates.yml
@@ -65,7 +65,7 @@ jobs:
                   
                   READY=true
                   echo "Worker ready"
-                  exit 0
+                  break
                 fi
                 echo "Attempt $i: worker not ready yet..."
                 sleep 2

--- a/portfolio-chatbot/wrangler.jsonc
+++ b/portfolio-chatbot/wrangler.jsonc
@@ -20,12 +20,6 @@
       }
     ]
   },
-  
-  "vars": {
-  "OPENAI_API_KEY": "",
-  "SUPABASE_URL": "",
-  "SUPABASE_SERVICE_ROLE_KEY": ""
-  },
 
   "observability": {
     "enabled": true


### PR DESCRIPTION
This pull request contains minor changes focused on workflow reliability and configuration cleanup.

- **Workflow Reliability**
  * In `.github/workflows/weekly-regression-gates.yml`, replaced `exit 0` with `break` in the worker readiness loop to prevent the entire script from exiting prematurely and allow subsequent steps to run as intended.

- **Configuration Cleanup**
  * Removed the unused `vars` block (including API keys and URLs) from `portfolio-chatbot/wrangler.jsonc` to clean up configuration and reduce the risk of exposing sensitive information.