### PR TITLE
fix: add environment variables to worker startup in weekly regression…

### DIFF
--- a/.github/workflows/weekly-regression-gates.yml
+++ b/.github/workflows/weekly-regression-gates.yml
@@ -51,6 +51,9 @@ jobs:
           cd portfolio-chatbot
 
           echo "Starting worker..."
+          OPENAI_API_KEY="$OPENAI_API_KEY" \
+          SUPABASE_URL="$SUPABASE_URL" \
+          SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY" \ 
           npm run dev 2>&1 | tee worker.log &
           
           echo "Waiting for worker to be ready..."

--- a/portfolio-chatbot/wrangler.jsonc
+++ b/portfolio-chatbot/wrangler.jsonc
@@ -20,6 +20,12 @@
       }
     ]
   },
+  
+  "vars": {
+  "OPENAI_API_KEY": "",
+  "SUPABASE_URL": "",
+  "SUPABASE_SERVICE_ROLE_KEY": ""
+  },
 
   "observability": {
     "enabled": true


### PR DESCRIPTION
This pull request introduces improvements to environment variable management for the project, ensuring that sensitive configuration values are set explicitly and consistently across both local development and deployment environments.

Environment variable management:

* [`.github/workflows/weekly-regression-gates.yml`](diffhunk://#diff-159f08b63d3789f28ebbdc4e5c68b06dc617a231254766b5693ab5f9d0ea6a32R54-R56): Updated the worker startup command to explicitly pass `OPENAI_API_KEY`, `SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY` as environment variables when running the development server.
* [`portfolio-chatbot/wrangler.jsonc`](diffhunk://#diff-673b796f82b4cbfc69d6e0752b25fa7e45ee629e42eb0f290bcadfa135f7a0caR24-R29): Added a `vars` section to define `OPENAI_API_KEY`, `SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY` as configurable variables for the project.