### PR TITLE
feat: add closeChat method to HomePage and enhance clipboard test for…

### DIFF
--- a/.github/workflows/pr-quality-gates.yml
+++ b/.github/workflows/pr-quality-gates.yml
@@ -1,5 +1,8 @@
 name: PR Quality Gates
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  
 on:
   pull_request:
     branches: [main]

--- a/e2e/pages/HomePage.ts
+++ b/e2e/pages/HomePage.ts
@@ -79,6 +79,10 @@ async openChat() {
   await this.chatBubble().click();
   await expect(this.chatWindow()).toBeVisible();
 }
+async closeChat() {
+  await this.chatBubble().click();
+  await expect(this.chatWindow()).not.toBeVisible();
+}
 async waitForGreeting() {
   // Wait until assistant message is non-empty
   await expect(this.assistantMessages().first()).not.toHaveText("");

--- a/e2e/specs/navigation.spec.ts
+++ b/e2e/specs/navigation.spec.ts
@@ -2,6 +2,38 @@
 import { test, expect  } from "../fixtures/test";
 import { assertExternalLinkOpensCorrectly } from "../utils/assertExternalLink";
 
+test('Copy Email Header Button works', async ({ home, page }) => {
+// Copy email button: should copy to clipboard and change text
+await page.addInitScript(() => {
+  // Mock clipboard API for testing since Playwright doesn't have native clipboard support. 
+  //  This mock allows us to verify that the correct text is being "copied" when the button is clicked.
+  const clipboardStore = { value: "" };
+  Object.defineProperty(navigator, "clipboard", {
+    value: {
+      writeText: async (text: string) => {
+        clipboardStore.value = text;
+      },
+      readText: async () => clipboardStore.value,
+    },
+    configurable: true,
+  });
+});
+
+await home.goto();
+const btnHeader = page
+  .locator('section#section .ContainerOfBtn button');
+await expect(btnHeader).toHaveText("Copy email");
+await btnHeader.click();
+// Assert UI change
+await expect(btnHeader).toHaveText("Copied");
+// Assert clipboard value
+const clipboardText = await page.evaluate(() =>
+  navigator.clipboard.readText()
+);
+expect(clipboardText).toBe("davidstevenabril@gmail.com");
+// Assert revert
+await expect(btnHeader).toHaveText("Copy email", { timeout: 4000 });
+})
 const cases = [ //Objects for test cases, each with a nav item and the expected heading it should scroll to
   { nav: "Projects",   slug: "projects" },
   { nav: "Diplomas",   slug: "diplomas" },
@@ -42,38 +74,8 @@ test('Email Button header work', async ({ home, page }) => {
   await expect(emailBtn).toBeEnabled();
   await expect(emailBtn).toHaveAttribute('href', /^mailto:/i);
 });
-test('Copy Email Header Button works', async ({ home, page }) => {
-// Copy email button: should copy to clipboard and change text
-await page.addInitScript(() => {
-  // Mock clipboard API for testing since Playwright doesn't have native clipboard support. 
-  //  This mock allows us to verify that the correct text is being "copied" when the button is clicked.
-  const clipboardStore = { value: "" };
-  Object.defineProperty(navigator, "clipboard", {
-    value: {
-      writeText: async (text: string) => {
-        clipboardStore.value = text;
-      },
-      readText: async () => clipboardStore.value,
-    },
-    configurable: true,
-  });
-});
 
-await home.goto();
-const btnHeader = page
-  .locator('section#section .ContainerOfBtn button');
-await expect(btnHeader).toHaveText("Copy email");
-await btnHeader.click();
-// Assert UI change
-await expect(btnHeader).toHaveText("Copied");
-// Assert clipboard value
-const clipboardText = await page.evaluate(() =>
-  navigator.clipboard.readText()
-);
-expect(clipboardText).toBe("davidstevenabril@gmail.com");
-// Assert revert
-await expect(btnHeader).toHaveText("Copy email", { timeout: 4000 });
-})
+
 test("Home page external buttons work", async ({ home, page }) => {
   await home.goto();
     const btnLinkedInHeader = home.externalLink(/^LinkedIn$/i, 0);
@@ -169,4 +171,6 @@ test("chatbot opens and responds to mocked user message", async ({ home, page })
   await home.waitForAssistantReply();
   await expect(home.assistantMessages().last())
     .toContainText("Mocked assistant response");
+  await home.closeChat();
+
 });


### PR DESCRIPTION
This pull request primarily improves end-to-end (E2E) test coverage and maintainability for the project. The most significant change is the refactoring of the "Copy Email Header Button" test for better organization. Additionally, a new utility method for closing the chat window is introduced, and a workflow environment variable is set to ensure Node.js 24 compatibility for JavaScript actions.

**E2E Test Improvements:**

* Refactored the "Copy Email Header Button works" test in `e2e/specs/navigation.spec.ts` by moving it to an earlier position in the file, improving test organization and clarity. The test uses a clipboard API mock to verify copying functionality, UI feedback, and clipboard content. [[1]](diffhunk://#diff-bea88ec7389f0d005b9f4eb7ed78ee01795c659711ba97b44103fcbd7ee76b59R5-R36) [[2]](diffhunk://#diff-bea88ec7389f0d005b9f4eb7ed78ee01795c659711ba97b44103fcbd7ee76b59L45-R78)
* Added a call to a new `closeChat` method at the end of the chatbot E2E test to ensure proper cleanup after the test runs.
* Added a new `closeChat` method to the `HomePage` page object to encapsulate chat window closing logic for reuse in tests.

**Workflow Configuration:**

* Set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable in the `.github/workflows/pr-quality-gates.yml` workflow to enforce Node.js 24 usage for JavaScript GitHub Actions.