### PR TITLE
feat: set maximum allowed lint errors to 0 and improve chat auto-scro…

### DIFF
--- a/.github/workflows/lint-quality-gate.yml
+++ b/.github/workflows/lint-quality-gate.yml
@@ -1,7 +1,7 @@
 name: Lint Quality Gate
 
 env:
-  MAX_ALLOWED_LINT_ERRORS: 3
+  MAX_ALLOWED_LINT_ERRORS: 0
 
 on:
   pull_request:

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -197,11 +197,12 @@ const scrollToAnchorTop = (el: HTMLDivElement) => {
   const container = scrollContainerRef.current;
   if (!container) return;
 
-  const delta =
-    el.getBoundingClientRect().top -
-    container.getBoundingClientRect().top;
+  const top = el.offsetTop - container.offsetTop;
 
-  container.scrollTop += delta;
+  container.scrollTo({
+    top,
+    behavior: "auto"
+  });
 };
 
 const goPrevQuestion = () => {


### PR DESCRIPTION
This pull request introduces two main changes: it enforces stricter linting by not allowing any lint errors in the GitHub Actions workflow, and it improves the scrolling logic in the `ChatWidget` component for more predictable behavior.

**Linting policy update:**

* Updated `.github/workflows/lint-quality-gate.yml` to set `MAX_ALLOWED_LINT_ERRORS` to 0, enforcing that no lint errors are allowed in pull requests.

**UI behavior improvement:**

* Refactored the `scrollToAnchorTop` function in `src/components/ChatWidget.tsx` to use `scrollTo` with a calculated `top` value based on `offsetTop`, resulting in more accurate and consistent scrolling to elements.