### PR TITLE
fix: add rate limit metrics upload and adjust reliability scoring in …

### DIFF
--- a/.github/workflows/weekly-regression-gates.yml
+++ b/.github/workflows/weekly-regression-gates.yml
@@ -120,6 +120,35 @@ jobs:
           cd portfolio-chatbot
           node scripts/upload-metrics.js
 
+      - name: Fetch regression summary
+        id: summary
+        run: |
+          node << 'EOF'
+          const SUPABASE_URL = process.env.SUPABASE_URL;
+          const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+          async function main() {
+            const res = await fetch(
+              `${SUPABASE_URL}/rest/v1/regression_run_summary?order=run_timestamp.desc&limit=1`,
+              {
+                headers: {
+                  apikey: SUPABASE_KEY,
+                  Authorization: `Bearer ${SUPABASE_KEY}`
+                }
+              }
+            );
+
+            const data = await res.json();
+            const r = data[0];
+
+            console.log(`p95=${r.p95_latency}`);
+            console.log(`confidence=${r.avg_confidence}`);
+            console.log(`enforcement=${r.enforcement_rate}`);
+          }
+
+          main();
+          EOF
+
       # Dashboard
       - name: Compare with previous runs from DB
         id: dbcompare
@@ -211,8 +240,14 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🚀 Release Confidence" >> $GITHUB_STEP_SUMMARY
 
+          echo "### 📊 Key Metrics" >> $GITHUB_STEP_SUMMARY
+          echo "- P95 latency: ${{ steps.summary.outputs.p95 }} ms" >> $GITHUB_STEP_SUMMARY
+          echo "- Avg confidence: ${{ steps.summary.outputs.confidence }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Rate limit enforcement: ${{ steps.summary.outputs.enforcement }}" >> $GITHUB_STEP_SUMMARY
+
           if [ "$REGRESSION_STATUS" = "PASS" ]; then
             echo "✅ System is stable across retrieval, performance, and abuse protection" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ Regression detected — investigation required" >> $GITHUB_STEP_SUMMARY
           fi
+

--- a/portfolio-chatbot/scripts/upload-metrics.js
+++ b/portfolio-chatbot/scripts/upload-metrics.js
@@ -94,6 +94,11 @@ async function uploadRetrieval(metrics) {
   }
 }
 
+async function uploadRateLimit(metrics) {
+  for (const m of metrics) {
+    await insert("rate_limit_metrics", m);
+  }
+}
 /**
  * Upload test_results summary
  */
@@ -144,8 +149,10 @@ function computeReliability(artifacts) {
 
     if (a.suite === "rate_limit_regression") {
       const m = a.metrics[0];
-      if (m.threshold_drift > 3) rateLimitScore -= 20;
-      if (m.enforcement_rate < 0.1) rateLimitScore -= 20;
+      if (m.enforcement_rate < 0.3) rateLimitScore -= 10;
+      if (m.enforcement_rate < 0.1) rateLimitScore -= 10;
+      if (m.threshold_drift > 1) rateLimitScore -= 10;
+      if (m.threshold_drift > 3) rateLimitScore -= 10;
     }
   }
   
@@ -162,7 +169,8 @@ function computeReliability(artifacts) {
 
 async function uploadPerformance(metrics) {
   for (const m of metrics) {
-    await insert("performance_metrics", m);
+    const { test_id, ...payload } = m;
+    await insert("performance_metrics", payload);
   }
 }
 
@@ -223,6 +231,9 @@ async function main() {
     }
     if (artifact.suite === "performance_regression") {
     await uploadPerformance(artifact.metrics);
+    }
+    if (artifact.suite === "rate_limit_regression") {
+      await uploadRateLimit(artifact.metrics);
     }
     await uploadTestResult(artifact.suite, artifact.metrics);
   }


### PR DESCRIPTION
This pull request enhances the weekly regression workflow and metric upload scripts to provide more detailed reporting and improved reliability scoring. The main changes include fetching and displaying key regression metrics in the workflow summary, adjusting the reliability scoring criteria, and supporting the upload of rate limit metrics to the database.

**Workflow and Reporting Improvements:**

* Added a new step in `.github/workflows/weekly-regression-gates.yml` to fetch the latest regression summary from Supabase and output key metrics: p95 latency, average confidence, and enforcement rate. These metrics are now included in the GitHub Actions summary for better visibility. [[1]](diffhunk://#diff-159f08b63d3789f28ebbdc4e5c68b06dc617a231254766b5693ab5f9d0ea6a32R123-R151) [[2]](diffhunk://#diff-159f08b63d3789f28ebbdc4e5c68b06dc617a231254766b5693ab5f9d0ea6a32R243-R253)

**Metric Upload and Scoring Adjustments:**

* Updated `portfolio-chatbot/scripts/upload-metrics.js` to support uploading rate limit metrics by introducing a new `uploadRateLimit` function and invoking it for `rate_limit_regression` artifacts. [[1]](diffhunk://#diff-9122b53079ba5ae683aa4e90c08fd16809d38bc1720d6b8a4ed365d42489a123R97-R101) [[2]](diffhunk://#diff-9122b53079ba5ae683aa4e90c08fd16809d38bc1720d6b8a4ed365d42489a123R235-R237)
* Refined the reliability scoring logic for rate limit regression: reduced penalty thresholds and split penalties for enforcement rate and threshold drift to provide more granular scoring.
* Modified the `uploadPerformance` function to exclude the `test_id` field when uploading performance metrics, ensuring only relevant data is stored.