### PR TITLE
fix: update upload functions to include run_id and improve payload st…

### DIFF
--- a/portfolio-chatbot/scripts/upload-metrics.js
+++ b/portfolio-chatbot/scripts/upload-metrics.js
@@ -90,14 +90,29 @@ async function createTestRun() {
  */
 async function uploadRetrieval(metrics) {
   for (const m of metrics) {
-    await insert("retrieval_metrics", m);
+    const payload = {
+      run_id: RUN_ID,
+      query: m.query,
+      overlap_ratio: m.overlap_ratio,
+      rank_shift: m.rank_shift,
+      confidence: m.confidence
+    };
+
+    await insert("retrieval_metrics", payload);
   }
 }
 
 async function uploadRateLimit(metrics) {
   for (const m of metrics) {
-    const { test_id, ...payload } = m;
-    await insert("rate_limit_metrics", m);
+    const payload = {
+      run_id: RUN_ID,
+      total_requests: m.total_requests,
+      total_429: m.total_429,
+      enforcement_rate: m.enforcement_rate,
+      first_429_index: m.first_429_index,
+      threshold_drift: m.threshold_drift
+    };
+    await insert("rate_limit_metrics", payload);
   }
 }
 /**
@@ -106,7 +121,7 @@ async function uploadRateLimit(metrics) {
 async function uploadTestResult(suite, metrics) {
   const status = "passed"; // since test already passed
   const duration = metrics.reduce(
-  (acc, m) => acc + (m.mean_latency * m.sample_size),
+  (acc, m) => acc + ((m.mean_latency || 0) * (m.sample_size || 0)),
   0
   );
 
@@ -170,7 +185,13 @@ function computeReliability(artifacts) {
 
 async function uploadPerformance(metrics) {
   for (const m of metrics) {
-    const { test_id, ...payload } = m;
+    const payload = {
+      run_id: RUN_ID,
+      p95_latency: m.p95_latency,
+      degradation_ratio: m.degradation_ratio,
+      concurrent_p95: m.concurrent_p95
+    };
+
     await insert("performance_metrics", payload);
   }
 }


### PR DESCRIPTION
This pull request refactors the way metrics are uploaded in the `portfolio-chatbot/scripts/upload-metrics.js` script to ensure only specific, relevant fields are sent to the database for each metric type. It also improves the robustness of the test result duration calculation.

**Metrics Upload Refactoring:**

* The `uploadRetrieval`, `uploadRateLimit`, and `uploadPerformance` functions now construct explicit payload objects with only the necessary fields (`run_id` and relevant metric values) before inserting into their respective tables, rather than inserting the entire metric object. [[1]](diffhunk://#diff-9122b53079ba5ae683aa4e90c08fd16809d38bc1720d6b8a4ed365d42489a123L93-R115) [[2]](diffhunk://#diff-9122b53079ba5ae683aa4e90c08fd16809d38bc1720d6b8a4ed365d42489a123L173-R194)

**Test Result Calculation Robustness:**

* In `uploadTestResult`, the duration calculation now safely handles missing values by defaulting `mean_latency` and `sample_size` to 0 if they are undefined or null.