### PR TITLE
Fix lint errors

### DIFF
--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -100,7 +100,7 @@ export const test = base.extend<Fixtures>({
   page: async ({ page }, use) => {
     // Inject BEFORE navigation / app init
     await page.addInitScript(() => {
-      (window as any).__TEST__ = true;
+      (window as Window & { __TEST__?: boolean }).__TEST__ = true;
     });
 
     await use(page);

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -94,32 +94,42 @@ const e2eMetrics: E2ETestMetric[] = [];
 
 export const test = base.extend<Fixtures>({
   /**
-   * Fixture: consoleErrors
-   * Captures all console errors and page errors that occur during test execution
-   * Filters out known benign errors using the ALLOWLIST
+   * Fixture: page (override)
+   * Injects test flag BEFORE any page loads
    */
-  consoleErrors: async ({ page }, provideFixture) => {
-    const errors: string[] = [];
-
-    // Listen for uncaught JavaScript errors on the page
-    page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
-
-    // Listen for console.error() messages
-    page.on("console", (msg) => {
-      if (msg.type() === "error") errors.push(`console: ${msg.text()}`);
+  page: async ({ page }, use) => {
+    // Inject BEFORE navigation / app init
+    await page.addInitScript(() => {
+      (window as any).__TEST__ = true;
     });
 
-    // Provide errors array to test, then clean up listeners
-    await provideFixture(errors);
+    await use(page);
+  },
+
+  /**
+   * Fixture: consoleErrors
+   */
+  consoleErrors: async ({ page }, use) => {
+    const errors: string[] = [];
+
+    page.on("pageerror", (err) =>
+      errors.push(`pageerror: ${err.message}`)
+    );
+
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        errors.push(`console: ${msg.text()}`);
+      }
+    });
+
+    await use(errors);
   },
 
   /**
    * Fixture: home
-   * Provides a HomePage POM instance for test to use
-   * Attached to page context, reusable across multiple test steps
    */
-  home: async ({ page }, provideFixture) => {
-    await provideFixture(new HomePage(page));
+  home: async ({ page }, use) => {
+    await use(new HomePage(page));
   },
 });
 

--- a/e2e/pages/HomePage.ts
+++ b/e2e/pages/HomePage.ts
@@ -50,6 +50,8 @@ export class HomePage {
         *, *::before, *::after {
           animation: none !important;
           transition: none !important;
+          transform: none !important;
+          backdrop-filter: none !important;
         }
         html, body {
           scroll-behavior: auto !important;
@@ -144,36 +146,7 @@ assistantMessages() {
 userMessages() {
   return this.page.locator(".chat-user");
 }
-private async waitForStableText(locator: Locator, stableChecks = 3, timeoutMs = 20000) {
-  // Poll message content until it stops changing for several consecutive checks.
-  let last = "";
-  let stableCount = 0;
 
-  await expect
-    .poll(
-      async () => {
-        const current = (await locator.textContent())?.trim() ?? "";
-        if (!current) {
-          stableCount = 0;
-          last = current;
-          return false;
-        }
-        if (current === last) {
-          stableCount += 1;
-        } else {
-          stableCount = 1;
-          last = current;
-        }
-        return stableCount >= stableChecks;
-      },
-      {
-        timeout: timeoutMs,
-        intervals: [150, 300, 500],
-        message: "Assistant message did not stabilize before timeout",
-      }
-    )
-    .toBe(true);
-}
 async openChat() {
   const bubble = this.chatBubble();
   await expect(bubble).toBeVisible();
@@ -187,14 +160,16 @@ async closeChat() {
 async waitForGreeting() {
   const firstAssistant = this.assistantMessages().first();
   await firstAssistant.waitFor({ state: "visible" });
-  await this.waitForStableText(firstAssistant);
+  await expect(firstAssistant).toContainText(" no personal information is stored");
 }
 async sendChatMessage(text: string) {
   await this.chatInput().fill(text);
   await this.chatInput().press("Enter");
 }
 async waitForAssistantReply() {
-  await this.waitForStableText(this.assistantMessages().last());
+  const lastAssistant = this.assistantMessages().last();
+  await lastAssistant.waitFor({ state: "visible" });
+  await expect(lastAssistant).toContainText("Mocked assistant response");
 }
 
 

--- a/e2e/utils/assertExternalLink.ts
+++ b/e2e/utils/assertExternalLink.ts
@@ -19,14 +19,10 @@ export async function assertExternalLinkOpensCorrectly(
 
   expect(href).toBeTruthy();
 
-  const context = page.context();
-  const knownPages = new Set(context.pages());
-  const newPagePromise = context
-    .waitForEvent("page", { predicate: (p) => !knownPages.has(p), timeout: 5000 })
-    .catch(() => null);
+  const popupPromise = page.waitForEvent("popup", { timeout: 5000 }).catch(() => null);
 
   await link.click();
-  const popup = await newPagePromise;
+  const popup = await popupPromise;
 
   const url = popup
     ? (await popup.waitForLoadState("domcontentloaded", { timeout: 10000 }), new URL(popup.url()))

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,4 +25,11 @@ export default defineConfig([
       }
     }
   },
+  {
+    files: ['e2e/**/*.ts'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/scripts/lighthouse-summary.mjs
+++ b/scripts/lighthouse-summary.mjs
@@ -39,7 +39,7 @@ const reports = files.map(f => {
   const lhr = JSON.parse(fs.readFileSync(`.lighthouseci/${f}`, "utf8"));
   const c = lhr.categories ?? {};
   return {
-    url: lhr.finalUrl ?? lhr.requestedUrl ?? f,
+    url: lhr.requestedUrl ?? lhr.finalUrl ?? f,
     perf: pct(c.performance?.score),
     a11y: pct(c.accessibility?.score),
     bp: pct(c["best-practices"]?.score),

--- a/src/App.css
+++ b/src/App.css
@@ -242,6 +242,7 @@ html[data-test-mode="true"] *::after {
   animation: none !important;
   transition: none !important;
   transform: none !important;
+  backdrop-filter: none !important;
 }
 
 /* disable smooth scrolling */

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -60,6 +60,9 @@ export default function ChatWidget({
   const pendingContextRef = useRef<string | null>(null);
 
   const TYPING_SPEED = 13;
+  const isTestRuntime =
+  typeof window !== "undefined" &&
+  (window as any).__TEST__ === true;
   const savedScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const bubbleRef = useRef<HTMLButtonElement | null>(null);
@@ -159,34 +162,74 @@ export default function ChatWidget({
     }
   }, [isStreaming, handleStreamingFinishedScroll]);
 
-  // Typewriter effect for greeting
-  useEffect(() => {
-    if (!isTypingGreeting) return;
-    if (greetingIndex >= greetingText.length) {
-      setIsTypingGreeting(false);
-      requestAnimationFrame(() => {
-        if (scrollContainerRef.current) {
-          scrollContainerRef.current.scrollTop = scrollContainerRef.current.scrollHeight;
-        }
-      });
-      return;
-    }
+ // Typewriter effect for greeting
+useEffect(() => {
+  if (!isTypingGreeting) return;
 
-    const timeout = setTimeout(() => {
-      const nextChar = greetingText[greetingIndex];
-      setMessages((prev) => {
-        const updated = [...prev];
-        const last = updated[updated.length - 1];
-        if (last && last.role === "assistant") {
-          updated[updated.length - 1] = { ...last, content: last.content + nextChar };
-        }
-        return updated;
-      });
-      setGreetingIndex((prev) => prev + 1);
-    }, TYPING_SPEED);
+  // ✅ TEST MODE: render instantly (no streaming)
+  if (isTestRuntime) {
+    setMessages((prev) => {
+      const updated = [...prev];
+      const last = updated[updated.length - 1];
 
-    return () => clearTimeout(timeout);
-  }, [greetingIndex, isTypingGreeting, greetingText]);
+      if (last && last.role === "assistant") {
+        updated[updated.length - 1] = {
+          ...last,
+          content: greetingText,
+        };
+      }
+
+      return updated;
+    });
+
+    setIsTypingGreeting(false);
+
+    requestAnimationFrame(() => {
+      if (scrollContainerRef.current) {
+        scrollContainerRef.current.scrollTop =
+          scrollContainerRef.current.scrollHeight;
+      }
+    });
+
+    return;
+  }
+
+  // ✅ NORMAL MODE: typewriter effect
+  if (greetingIndex >= greetingText.length) {
+    setIsTypingGreeting(false);
+
+    requestAnimationFrame(() => {
+      if (scrollContainerRef.current) {
+        scrollContainerRef.current.scrollTop =
+          scrollContainerRef.current.scrollHeight;
+      }
+    });
+
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    const nextChar = greetingText[greetingIndex];
+
+    setMessages((prev) => {
+      const updated = [...prev];
+      const last = updated[updated.length - 1];
+
+      if (last && last.role === "assistant") {
+        updated[updated.length - 1] = {
+          ...last,
+          content: last.content + nextChar,
+        };
+      }
+
+      return updated;
+    });
+
+    setGreetingIndex((prev) => prev + 1);
+  }, TYPING_SPEED);
+
+  return () => clearTimeout(timeout);
+}, [greetingIndex, isTypingGreeting, greetingText]);
 
   // External query: open chat and pre-fill input.
   // If an externalContext was provided alongside the query, capture it into the

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -62,7 +62,7 @@ export default function ChatWidget({
   const TYPING_SPEED = 13;
   const isTestRuntime =
   typeof window !== "undefined" &&
-  (window as any).__TEST__ === true;
+  (window as Window & { __TEST__?: boolean }).__TEST__ === true;
   const savedScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const bubbleRef = useRef<HTMLButtonElement | null>(null);
@@ -229,7 +229,7 @@ useEffect(() => {
   }, TYPING_SPEED);
 
   return () => clearTimeout(timeout);
-}, [greetingIndex, isTypingGreeting, greetingText]);
+}, [greetingIndex, isTypingGreeting, greetingText, isTestRuntime]);
 
   // External query: open chat and pre-fill input.
   // If an externalContext was provided alongside the query, capture it into the

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -270,6 +270,7 @@ nav .badge {
     transition: none !important;
   }
 }
+
 @media (prefers-reduced-motion: no-preference) {
   .btn:hover {
     animation: float-idle-small 2s ease-in-out infinite;


### PR DESCRIPTION
#125 
This pull request introduces several improvements to end-to-end (E2E) test reliability and speed by enabling a dedicated "test mode" for the application. The main changes include injecting a test flag into the browser environment, updating E2E fixtures and page objects to leverage this flag, and modifying the chat widget to instantly render the greeting message during test runs. Additional minor improvements and bug fixes are included for CSS and test utilities.

**Test mode and E2E reliability improvements:**

* Added a fixture override in `e2e/fixtures/test.ts` to inject a `__TEST__` flag into the browser environment before any page loads, enabling test-specific behaviors in the app. Updated all custom fixtures to use the new Playwright fixture API (`use`) for consistency and reliability.
* Updated `ChatWidget.tsx` to detect the `__TEST__` flag and, when present, instantly render the greeting message instead of using the typewriter effect. This ensures E2E tests are faster and less flaky. [[1]](diffhunk://#diff-0d8b13ed021cc0b40df2d247a5bdfd7c27cbff646de279c689f28b1b8a8b16ceR63-R65) [[2]](diffhunk://#diff-0d8b13ed021cc0b40df2d247a5bdfd7c27cbff646de279c689f28b1b8a8b16ceR168-R232)
* Modified the `HomePage` page object and related E2E tests to assert for the presence of expected greeting and assistant reply texts, removing the now-unnecessary polling for stable text. [[1]](diffhunk://#diff-388a167a0653a39202dffdfc7e65fb7188f1cd657dcb012505083db88ee097b5L147-R149) [[2]](diffhunk://#diff-388a167a0653a39202dffdfc7e65fb7188f1cd657dcb012505083db88ee097b5L190-R172)

**Test and linting configuration:**

* Disabled React Hooks linting rules for E2E test files in `eslint.config.js` to avoid irrelevant warnings.

**Minor fixes and improvements:**

* Added `backdrop-filter: none !important;` to the test mode CSS in both `HomePage.ts` and `App.css` to further reduce flakiness caused by animations and visual effects during tests. [[1]](diffhunk://#diff-388a167a0653a39202dffdfc7e65fb7188f1cd657dcb012505083db88ee097b5R53-R54) [[2]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972R245)
* Simplified the logic for detecting new popups in the `assertExternalLinkOpensCorrectly` test utility.
* Changed the URL precedence in Lighthouse summary reporting to prefer `requestedUrl` over `finalUrl`.

These changes collectively improve the reliability, speed, and maintainability of the E2E test suite.