### PR TITLE
fix: Enhance accessibility tests and improve language response handli…

### DIFF
--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../fixtures/test";
 import AxeBuilder from "@axe-core/playwright";
 
 test("no critical accessibility violations on landing page", async ({ page, home }, testInfo) => {
+  test.setTimeout(60000);
   const start = Date.now();
   await home.goto();
   const loadMs = Date.now() - start;

--- a/e2e/specs/navigation.spec.ts
+++ b/e2e/specs/navigation.spec.ts
@@ -17,7 +17,7 @@ test('Copy Email Footer Button works', async ({ home, page }) => {
 await home.goto();
 const btnFooter = page.getByRole("button", { name: /^Copy email$/i }).nth(1);
 await expect(btnFooter).toHaveText("Copy email");
-await btnFooter.scrollIntoViewIfNeeded();
+await btnFooter.evaluate(el => el.scrollIntoView({ behavior: 'instant', block: 'center' }));
 await btnFooter.click();
 await expect.poll(async () => (await btnFooter.textContent())?.trim()).toMatch(
   /^(Copied|Copy email)$/

--- a/portfolio-chatbot/src/__tests__/retrieval.regression.test.ts
+++ b/portfolio-chatbot/src/__tests__/retrieval.regression.test.ts
@@ -40,6 +40,7 @@ const ARCH_QUESTION = {
 
 /**
  * Known grounded keywords expected in the response based on current portfolio content and architecture.
+ * RAG, CI, Cloudflare are universal acronyms/proper nouns that appear in any language answer.
  */
 const EXPECTED_CONCEPTS = [
   "rag",
@@ -51,6 +52,21 @@ const EXPECTED_CONCEPTS = [
   "ci",
   "debug",
 ];
+
+/**
+ * Per-language concept aliases for the same architectural concepts above.
+ * Lets concept_score reflect actual grounding even when the answer is in a non-English language,
+ * where translated words replace the English originals.
+ * concept_score is used as an observability metric (not a hard gate), so accuracy matters.
+ */
+const CONCEPT_ALIASES: Record<string, string[]> = {
+  es: ["recuperación", "seguridad", "prueba", "depuración", "vector", "observabilidad"],
+  fr: ["récupération", "sécurité", "essai", "débogage", "vecteur", "observabilité"],
+  pt: ["recuperação", "segurança", "teste", "depuração", "vetor", "observabilidade"],
+  de: ["abruf", "sicherheit", "prüfung", "debugging", "vektor", "beobachtbarkeit"],
+  zh: ["检索", "安全", "测试", "调试", "向量", "可观测"],
+  ja: ["検索", "セキュリティ", "テスト", "デバッグ", "ベクトル", "可観測性"],
+};
 
 interface RetrievalDocument {
   id: string;
@@ -186,9 +202,10 @@ describe.runIf(process.env.NIGHTLY === "true")(
         expect(shift).toBeLessThan(MAX_RANK_SHIFT);
 
         // --- 4. Concept grounding (answer must reflect retrieved knowledge)
-        const conceptScore = EXPECTED_CONCEPTS.reduce((acc, c) => {
-          return r.answer.toLowerCase().includes(c) ? acc + 1 : acc;
-        }, 0);
+        // English concepts + per-language aliases so non-English answers score fairly
+        const answerLc = r.answer.toLowerCase();
+        const allConcepts = [...EXPECTED_CONCEPTS, ...(CONCEPT_ALIASES[lang] ?? [])];
+        const conceptScore = allConcepts.reduce((acc, c) => acc + (answerLc.includes(c) ? 1 : 0), 0);
 
         expect(conceptScore).toBeGreaterThanOrEqual(1);
 
@@ -244,7 +261,8 @@ describe.runIf(process.env.NIGHTLY === "true")(
 
 it("should not hallucinate when knowledge is absent", async () => {
     const probe = await ask("What Kubernetes clusters were used in the chatbot architecture?","en");
-    const answerLower = probe.answer.toLowerCase();
+    // Normalize Unicode curly apostrophes (U+2018/U+2019) that LLMs commonly emit
+    const answerLower = probe.answer.toLowerCase().replace(/[\u2018\u2019]/g, "'");
 
       // --- Must explicitly deny unsupported knowledge
       expect(answerLower).toMatch(/(not|no|does not|did not|doesn't|didn't|don't|cannot|can't|were not)/);

--- a/portfolio-chatbot/src/index.ts
+++ b/portfolio-chatbot/src/index.ts
@@ -689,6 +689,15 @@ If asked about:
 
 ---
 
+## 🌍 LANGUAGE RULE
+
+Always respond in the same language as the user's question.
+If the user writes in Japanese → respond in Japanese.
+If the user writes in German → respond in German.
+This applies even when the retrieved context is in English.
+
+---
+
 ## 🧠 COMMUNICATION STYLE
 
 - First person


### PR DESCRIPTION
This pull request introduces several improvements to end-to-end and regression tests, with a focus on accessibility, language-aware concept grounding, and test reliability. The most significant updates are in the chatbot's regression tests, where concept detection is now language-aware, and the test suite is made more robust to language-specific outputs. Additionally, a language consistency rule is added to the chatbot instructions.

**Testing improvements:**

* Added a per-language concept alias mapping (`CONCEPT_ALIASES`) in `retrieval.regression.test.ts` to ensure concept grounding checks work for non-English responses, improving the accuracy of the `concept_score` metric.
* Updated the concept grounding test to include both English and localized concept aliases for fair scoring across different languages.
* Normalized Unicode curly apostrophes in chatbot answers during hallucination tests to reduce false negatives from LLM output variations.
* Increased the timeout for the accessibility E2E test to 60 seconds to reduce flakiness on slow environments.
* Improved the reliability of the "Copy Email Footer Button" E2E test by ensuring the button is scrolled into view using a more deterministic method.

**Chatbot instruction update:**

* Added a new language rule in `index.ts` instructing the chatbot to always respond in the user's language, regardless of the context language.

**Documentation and comments:**

* Clarified in-code comments regarding universal acronyms and the purpose of language aliases for concept grounding. [[1]](diffhunk://#diff-3eb3851c2ed9e16488bbb1843bfa0397bae3b89ec95fca607e9809ccb8ba8122R43) [[2]](diffhunk://#diff-3eb3851c2ed9e16488bbb1843bfa0397bae3b89ec95fca607e9809ccb8ba8122R56-R70)